### PR TITLE
Provide proper touch / click feedback in the app

### DIFF
--- a/app/src/main/res/drawable/ic_duration.xml
+++ b/app/src/main/res/drawable/ic_duration.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#ffbebebe"
         android:pathData="M15,1L9,1v2h6L15,1zM11,14h2L13,8h-2v6zM19.03,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.07,4.74 14.12,4 12,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9 9,-4.03 9,-9c0,-2.12 -0.74,-4.07 -1.97,-5.61zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_error.xml
+++ b/app/src/main/res/layout/fragment_error.xml
@@ -65,7 +65,8 @@
             android:gravity="center"
             tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
-        <android.support.v7.widget.AppCompatImageView
+        <android.support.v7.widget.AppCompatImageButton
+            style="@style/Widget.AppCompat.Button.Borderless"
             android:id="@+id/retry"
             android:layout_width="48dp"
             android:layout_height="48dp"

--- a/app/src/main/res/layout/item_app.xml
+++ b/app/src/main/res/layout/item_app.xml
@@ -13,6 +13,7 @@
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="72dp"
+        android:background="?selectableItemBackground"
         android:onClick="@{() -> vm.onClick()}">
 
         <View

--- a/app/src/main/res/layout/item_artifact.xml
+++ b/app/src/main/res/layout/item_artifact.xml
@@ -15,6 +15,7 @@
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="72dp"
+        android:background="?selectableItemBackground"
         android:onClick="@{() -> vm.onClick()}">
 
         <ProgressBar

--- a/app/src/main/res/layout/item_build.xml
+++ b/app/src/main/res/layout/item_build.xml
@@ -13,6 +13,7 @@
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="72dp"
+        android:background="?selectableItemBackground"
         android:onClick="@{() -> vm.onClick()}">
 
         <View
@@ -72,7 +73,6 @@
             android:layout_marginBottom="8dp"
             android:layout_marginStart="16dp"
             android:src="@drawable/ic_duration"
-            android:tint="@android:color/secondary_text_dark"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/last_build_time"
             app:layout_constraintTop_toTopOf="@+id/last_build_time" />


### PR DESCRIPTION
Instead of no feedback at all (at the moment) use the default Android ripple/selector from the support library.

 * will use the standard `?selectableItemBackground` on lists
 * use ImageButton instead of ImageView with the borderless style
 * remove textColor tint as it would darken on click, moved color into drawable directly instead